### PR TITLE
[jenkins] fix: github access token

### DIFF
--- a/source/_ext/ghreference.py
+++ b/source/_ext/ghreference.py
@@ -31,7 +31,7 @@ class GitHubReference(Directive):
     def run(self):
         node_list = nodes.bullet_list()
 
-        token = os.getenv('GITHUB_TOKEN')
+        token = os.getenv('GITHUB_ACCESS_TOKEN')
         if token:
             g = Github(token)
             repo = g.get_repo(self.arguments[0])

--- a/source/_ext/gitstamp.py
+++ b/source/_ext/gitstamp.py
@@ -110,13 +110,13 @@ def what_build_am_i(app):
         global gh
         global gh_repo
         global gh_user_cache
-        token = os.getenv('GITHUB_TOKEN')
+        token = os.getenv('GITHUB_ACCESS_TOKEN')
         if token:
             gh = Github(token)
             gh_repo = gh.get_repo('symbol/symbol-docs')
             gh_user_cache = {}
         else:
-            raise errors.ExtensionError("Missing GITHUB_TOKEN environment variable.")
+            raise errors.ExtensionError("Missing GITHUB_ACCESS_TOKEN environment variable.")
     except Exception as e:
         print(e)
         print("gitstamp extension enabled, but GitHub link failed. No GH links will be generated.")


### PR DESCRIPTION
Rename ``GITHUB_TOKEN`` => ``GITHUB_ACCESS_TOKEN``