### PR TITLE
[docs] fix: remove links to symbol-cli repo

### DIFF
--- a/source/_static/retired/symbol-cli/1.0.2.md
+++ b/source/_static/retired/symbol-cli/1.0.2.md
@@ -1,0 +1,1533 @@
+# Commands
+
+## Table of Contents
+
+- [Account](#account)
+    * [info](#info)
+    * [generate](#generate)
+- [Block](#block)
+    * [search](#search)
+    * [info](#info)
+    * [receipts](#receipts)
+- [Chain](#chain)
+    * [height](#height)
+    * [score](#score)
+- [Converter](#converter)
+    * [base32ToHexAddress](#base32ToHexAddress)
+    * [hexToBase32Address](#hexToBase32Address)
+    * [namespaceNameToId](#namespaceNameToId)
+    * [numericStringToUInt64](#numericStringToUInt64)
+    * [payloadToTransaction](#payloadToTransaction)
+    * [privateKeyToPublicKey](#privateKeyToPublicKey)
+    * [publicKeyToAddress](#publicKeyToAddress)
+    * [stringToKey](#stringToKey)
+- [Metadata](#metadata)
+    * [account](#account)
+    * [mosaic](#mosaic)
+    * [namespace](#namespace)
+- [Monitor](#monitor)
+    * [block](#block)
+    * [confirmed](#confirmed)
+    * [unconfirmed](#unconfirmed)
+    * [status](#status)
+    * [cosignature](#cosignature)
+    * [cosignature](#cosignature)
+    * [all](#all)
+- [Mosaic](#mosaic)
+    * [search](#search)
+    * [info](#info)
+- [Namespace](#namespace)
+    * [info](#info)
+    * [alias](#alias)
+    * [owned](#owned)
+- [Node](#node)
+    * [info](#info)
+    * [health](#health)
+    * [serverinfo](#serverinfo)
+    * [storageinfo](#storageinfo)
+- [Profile](#profile)
+    * [create](#create)
+    * [decrypt](#decrypt)
+    * [import](#import)
+    * [list](#list)
+    * [setdefault](#setdefault)
+- [Restriction](#restriction)
+    * [account](#account)
+    * [mosaicaddress](#mosaicaddress)
+    * [mosaicglobal](#mosaicglobal)
+- [Transaction](#transaction)
+    * [search](#search)
+    * [info](#info)
+    * [status](#status)
+    * [uri](#uri)
+    * [accountaddressrestriction](#accountaddressrestriction)
+    * [accountkeylink](#accountkeylink)
+    * [accountmetadata](#accountmetadata)
+    * [accountmosaicrestriction](#accountmosaicrestriction)
+    * [accountoperationrestriction](#accountoperationrestriction)
+    * [addressalias](#addressalias)
+    * [cosign](#cosign)
+    * [mosaic](#mosaic)
+    * [mosaicaddressrestriction](#mosaicaddressrestriction)
+    * [mosaicalias](#mosaicalias)
+    * [mosaicglobalrestriction](#mosaicglobalrestriction)
+    * [mosaicmetadata](#mosaicmetadata)
+    * [mosaicsupplychange](#mosaicsupplychange)
+    * [multisigmodification](#multisigmodification)
+    * [namespace](#namespace)
+    * [namespacemetadata](#namespacemetadata)
+    * [nodekeylink](#nodekeylink)
+    * [persistentharvestdelegation](#persistentharvestdelegation)
+    * [secretlock](#secretlock)
+    * [secretproof](#secretproof)
+    * [transfer](#transfer)
+    * [votingkeylink](#votingkeylink)
+    * [vrfkeylink](#vrfkeylink)
+## Account
+
+### info
+
+Failed to initialize libusb.
+
+  Get account information
+
+  USAGE
+
+    symbol-cli account info [...options]
+
+  OPTIONS
+
+    --profile <profile>     - (Optional) Select between your profiles, by providing a profile name.
+    -a, --address <address> - Account address.                                                     
+
+
+### generate
+
+Failed to initialize libusb.
+
+  Generate new accounts
+
+  USAGE
+
+    symbol-cli account generate [...options]
+
+  OPTIONS
+
+    --profile <profile>                      - (Optional) Select between your profiles, by providing a profile name.                                                                                                 
+    --hd                                     - (Optional) Create an HD wallet.                                                                                                                                       
+    --ledger                                 - (Optional) Create an Ledger wallet.                                                                                                                                   
+    -u, --url <url>                          - (Optional) When saving profile, provide a Symbol Node URL. Example: http://localhost:3000                                                                             
+    -n, --network <network>                  - (Optional) Network Type. (MAIN_NET, TEST_NET)                                                                                                                         
+    -p, --password <password>                - (Optional) When saving profile, provide the password.                                                                                                                 
+    -d, --default                            - (Optional) Set the profile as default.                                                                                                                                
+    -g, --generation-hash <generationHash>   - (Optional) Generation hash of the network. Required to create the profile offline.                                                                                    
+    -i, --namespace-id <namespaceId>         - (Optional) Namespace Name of the network mosaic. (eg.: symbol.xym) Required to create the profile offline.                                                            
+    -v, --divisibility <divisibility>        - (Optional) Divisibility of the network mosaic. (eg.: 6) Required to create the profile offline.                                                                       
+    -e, --epoch-adjustment <epochAdjustment> - (Optional) The epoch adjustment network configuration in seconds used to created the transaction`s deadline. (eg.: 1573430400) Required to create the profile offline.
+    -s, --save                               - (Optional) Saves the profile.                                                                                                                                         
+
+
+## Block
+
+### search
+
+Failed to initialize libusb.
+
+  Search transactions
+
+  USAGE
+
+    symbol-cli block search [...options]
+
+  OPTIONS
+
+    --profile <profile>                        - (Optional) Select between your profiles, by providing a profile name.       
+    -o, --order <order>                        - (Optional): Sort entries. (Desc: Newer to older, Asc: Older to newer) [Desc]
+    -n, --page-size <pageSize>                 - (Optional) Number of entries per page. [10]                                 
+    -n, --page-number <pageNumber>             - (Optional) Filter by page number. [1]                                       
+    -i, --offset <offset>                      - (Optional) Database entry id at which to start pagination.                  
+    --signer-public-key <signerPublicKey>      - (Optional) Public key of the account signing the entity.                    
+    --beneficiary-address <beneficiaryAddress> - (Optional) Filter by beneficiary address.                                   
+    --order-by <orderBy>                       - (Optional) Order by (Id, Height). [Id]                                      
+
+
+### info
+
+Failed to initialize libusb.
+
+  Get block header by height
+
+  USAGE
+
+    symbol-cli block info [...options]
+
+  OPTIONS
+
+    --profile <profile>   - (Optional) Select between your profiles, by providing a profile name.
+    -h, --height <height> - Block height.                                                        
+
+
+### receipts
+
+Failed to initialize libusb.
+
+  Get the receipts triggered for a given block height
+
+  USAGE
+
+    symbol-cli block receipts [...options]
+
+  OPTIONS
+
+    --profile <profile>   - (Optional) Select between your profiles, by providing a profile name.
+    -h, --height <height> - Block height.                                                        
+
+
+## Chain
+
+### height
+
+Failed to initialize libusb.
+
+  Get the current height of the chain
+
+  USAGE
+
+    symbol-cli chain height [...options]
+
+  OPTIONS
+
+    --profile <profile> - (Optional) Select between your profiles, by providing a profile name.
+
+
+### score
+
+Failed to initialize libusb.
+
+  Gets the current score of the chain
+
+  USAGE
+
+    symbol-cli chain score [...options]
+
+  OPTIONS
+
+    --profile <profile> - (Optional) Select between your profiles, by providing a profile name.
+
+
+## Converter
+
+### base32ToHexAddress
+
+
+  Address Base 32 -> Address hex converter.
+
+  USAGE
+
+    symbol-cli converter base32ToHexAddress [...options]
+
+  OPTIONS
+
+    --profile <profile>     - (Optional) Select between your profiles, by providing a profile name.
+    -a, --address <address> - Address.                                                             
+
+
+### hexToBase32Address
+
+
+  Address hex -> Address Base 32 converter.
+
+  USAGE
+
+    symbol-cli converter hexToBase32Address [...options]
+
+  OPTIONS
+
+    --profile <profile>     - (Optional) Select between your profiles, by providing a profile name.
+    -a, --address <address> - Address.                                                             
+
+
+### namespaceNameToId
+
+
+  Namespace name -> NamespaceId converter.
+
+  USAGE
+
+    symbol-cli converter namespaceNameToId [...options]
+
+  OPTIONS
+
+    --profile <profile>                  - (Optional) Select between your profiles, by providing a profile name.
+    -n, --namespace-name <namespaceName> - Namespace name.                                                      
+
+
+### numericStringToUInt64
+
+
+  Numeric string -> UInt64 converter.
+
+  USAGE
+
+    symbol-cli converter numericStringToUInt64 [...options]
+
+  OPTIONS
+
+    --profile <profile>   - (Optional) Select between your profiles, by providing a profile name.
+    -a, --amount <amount> - Numeric string. Example: 12345678                                    
+
+
+### payloadToTransaction
+
+
+  Payload -> Transaction converter.
+
+  USAGE
+
+    symbol-cli converter payloadToTransaction [...options]
+
+  OPTIONS
+
+    --profile <profile>     - (Optional) Select between your profiles, by providing a profile name.
+    -p, --payload <payload> - Transaction payload.                                                 
+
+
+### privateKeyToPublicKey
+
+
+  Private key -> Public key converter.
+
+  USAGE
+
+    symbol-cli converter privateKeyToPublicKey [...options]
+
+  OPTIONS
+
+    --profile <profile>            - (Optional) Select between your profiles, by providing a profile name.
+    -p, --private-key <privateKey> - Private Key.                                                         
+    -n, --network <network>        - Network Type. (MAIN_NET, TEST_NET)                                   
+
+
+### publicKeyToAddress
+
+
+  Public key -> Address converter.
+
+  USAGE
+
+    symbol-cli converter publicKeyToAddress [...options]
+
+  OPTIONS
+
+    --profile <profile>          - (Optional) Select between your profiles, by providing a profile name.
+    -p, --public-key <publicKey> - Public Key.                                                          
+    -n, --network <network>      - Network Type. (MAIN_NET, TEST_NET)                                   
+
+
+### stringToKey
+
+
+  String -> UInt64 converter.
+
+  USAGE
+
+    symbol-cli converter stringToKey [...options]
+
+  OPTIONS
+
+    --profile <profile> - (Optional) Select between your profiles, by providing a profile name.
+    -v, --value <value> - String value.                                                        
+
+
+## Metadata
+
+### account
+
+Failed to initialize libusb.
+
+  Fetch metadata entries from an account
+
+  USAGE
+
+    symbol-cli metadata account [...options]
+
+  OPTIONS
+
+    --profile <profile>     - (Optional) Select between your profiles, by providing a profile name.
+    -a, --address <address> - Target Address.                                                      
+
+
+### mosaic
+
+Failed to initialize libusb.
+
+  Fetch metadata entries from an mosaic
+
+  USAGE
+
+    symbol-cli metadata mosaic [...options]
+
+  OPTIONS
+
+    --profile <profile>        - (Optional) Select between your profiles, by providing a profile name.
+    -m, --mosaic-id <mosaicId> - Target mosaic id in hexadecimal format.                              
+
+
+### namespace
+
+Failed to initialize libusb.
+
+  Fetch metadata entries from an namespace
+
+  USAGE
+
+    symbol-cli metadata namespace [...options]
+
+  OPTIONS
+
+    --profile <profile>                  - (Optional) Select between your profiles, by providing a profile name.
+    -n, --namespace-name <namespaceName> - Target namespace name.                                               
+
+
+## Monitor
+
+### block
+
+Failed to initialize libusb.
+
+  Monitor new blocks
+
+  USAGE
+
+    symbol-cli monitor block [...options]
+
+  OPTIONS
+
+    --profile <profile> - (Optional) Select between your profiles, by providing a profile name.
+
+
+### confirmed
+
+Failed to initialize libusb.
+
+  Monitor confirmed transactions added
+
+  USAGE
+
+    symbol-cli monitor confirmed [...options]
+
+  OPTIONS
+
+    --profile <profile>     - (Optional) Select between your profiles, by providing a profile name.
+    -a, --address <address> - Account address.                                                     
+
+
+### unconfirmed
+
+Failed to initialize libusb.
+
+  Monitor unconfirmed transactions added
+
+  USAGE
+
+    symbol-cli monitor unconfirmed [...options]
+
+  OPTIONS
+
+    --profile <profile>     - (Optional) Select between your profiles, by providing a profile name.
+    -a, --address <address> - Account address.                                                     
+
+
+### status
+
+Failed to initialize libusb.
+
+  Monitor transaction status error
+
+  USAGE
+
+    symbol-cli monitor status [...options]
+
+  OPTIONS
+
+    --profile <profile>     - (Optional) Select between your profiles, by providing a profile name.
+    -a, --address <address> - Account address.                                                     
+
+
+### cosignature
+
+Failed to initialize libusb.
+
+  Monitor cosignatures added
+
+  USAGE
+
+    symbol-cli monitor cosignature [...options]
+
+  OPTIONS
+
+    --profile <profile>     - (Optional) Select between your profiles, by providing a profile name.
+    -a, --address <address> - Account address.                                                     
+
+
+### cosignature
+
+Failed to initialize libusb.
+
+  Monitor cosignatures added
+
+  USAGE
+
+    symbol-cli monitor cosignature [...options]
+
+  OPTIONS
+
+    --profile <profile>     - (Optional) Select between your profiles, by providing a profile name.
+    -a, --address <address> - Account address.                                                     
+
+
+### all
+
+Failed to initialize libusb.
+
+  Monitors new blocks, confirmed, aggregate bonded added, and status errors related to an account.
+
+  USAGE
+
+    symbol-cli monitor all [...options]
+
+  OPTIONS
+
+    --profile <profile>     - (Optional) Select between your profiles, by providing a profile name.
+    -a, --address <address> - Account address.                                                     
+
+
+## Mosaic
+
+### search
+
+Failed to initialize libusb.
+
+  Search mosaics
+
+  USAGE
+
+    symbol-cli mosaic search [...options]
+
+  OPTIONS
+
+    --profile <profile>            - (Optional) Select between your profiles, by providing a profile name.       
+    -o, --order <order>            - (Optional): Sort entries. (Desc: Newer to older, Asc: Older to newer) [Desc]
+    -n, --page-size <pageSize>     - (Optional) Number of entries per page. [10]                                 
+    -n, --page-number <pageNumber> - (Optional) Filter by page number. [1]                                       
+    -i, --offset <offset>          - (Optional) Database entry id at which to start pagination.                  
+    --owner-address <ownerAddress> - (Optional) Filter by owner address.                                         
+
+
+### info
+
+Failed to initialize libusb.
+
+  Fetch mosaic info
+
+  USAGE
+
+    symbol-cli mosaic info [...options]
+
+  OPTIONS
+
+    --profile <profile>        - (Optional) Select between your profiles, by providing a profile name.
+    -m, --mosaic-id <mosaicId> - Mosaic id in hexadecimal format.                                     
+
+
+## Namespace
+
+### info
+
+Failed to initialize libusb.
+
+  Fetch namespace info
+
+  USAGE
+
+    symbol-cli namespace info [...options]
+
+  OPTIONS
+
+    --profile <profile>                  - (Optional) Select between your profiles, by providing a profile name.
+    -n, --namespace-name <namespaceName> - Namespace name. Example: symbol.xym                                  
+    -h, --namespace-id <namespaceId>     - Namespace id in hexadecimal.                                         
+
+
+### alias
+
+Failed to initialize libusb.
+
+  Get mosaicId or address behind an namespace
+
+  USAGE
+
+    symbol-cli namespace alias [...options]
+
+  OPTIONS
+
+    --profile <profile>                  - (Optional) Select between your profiles, by providing a profile name.
+    -n, --namespace-name <namespaceName> - Namespace name.                                                      
+
+
+### owned
+
+Failed to initialize libusb.
+
+  Get owned namespaces
+
+  USAGE
+
+    symbol-cli namespace owned [...options]
+
+  OPTIONS
+
+    --profile <profile>     - (Optional) Select between your profiles, by providing a profile name.
+    -a, --address <address> - Account address.                                                     
+
+
+## Node
+
+### info
+
+Failed to initialize libusb.
+
+  Get the REST server components versions
+
+  USAGE
+
+    symbol-cli node info [...options]
+
+  OPTIONS
+
+    --profile <profile> - (Optional) Select between your profiles, by providing a profile name.
+
+
+### health
+
+Failed to initialize libusb.
+
+  Get information about the connection and services status
+
+  USAGE
+
+    symbol-cli node health [...options]
+
+  OPTIONS
+
+    --profile <profile> - (Optional) Select between your profiles, by providing a profile name.
+
+
+### serverinfo
+
+Failed to initialize libusb.
+
+  Get information about the REST instance
+
+  USAGE
+
+    symbol-cli node serverinfo [...options]
+
+  OPTIONS
+
+    --profile <profile> - (Optional) Select between your profiles, by providing a profile name.
+
+
+### storageinfo
+
+Failed to initialize libusb.
+
+  Get diagnostic information about the node storage
+
+  USAGE
+
+    symbol-cli node storageinfo [...options]
+
+  OPTIONS
+
+    --profile <profile> - (Optional) Select between your profiles, by providing a profile name.
+
+
+## Profile
+
+### create
+
+Failed to initialize libusb.
+
+  Create a new profile
+
+  USAGE
+
+    symbol-cli profile create [...options]
+
+  OPTIONS
+
+    --profile <profile>                      - (Optional) Select between your profiles, by providing a profile name.                                                                                                 
+    --hd                                     - (Optional) Create an HD wallet.                                                                                                                                       
+    --ledger                                 - (Optional) Create an Ledger wallet.                                                                                                                                   
+    -u, --url <url>                          - (Optional) When saving profile, provide a Symbol Node URL. Example: http://localhost:3000                                                                             
+    -n, --network <network>                  - (Optional) Network Type. (MAIN_NET, TEST_NET)                                                                                                                         
+    -p, --password <password>                - (Optional) When saving profile, provide the password.                                                                                                                 
+    -d, --default                            - (Optional) Set the profile as default.                                                                                                                                
+    -g, --generation-hash <generationHash>   - (Optional) Generation hash of the network. Required to create the profile offline.                                                                                    
+    -i, --namespace-id <namespaceId>         - (Optional) Namespace Name of the network mosaic. (eg.: symbol.xym) Required to create the profile offline.                                                            
+    -v, --divisibility <divisibility>        - (Optional) Divisibility of the network mosaic. (eg.: 6) Required to create the profile offline.                                                                       
+    -e, --epoch-adjustment <epochAdjustment> - (Optional) The epoch adjustment network configuration in seconds used to created the transaction`s deadline. (eg.: 1573430400) Required to create the profile offline.
+
+
+### decrypt
+
+Failed to initialize libusb.
+
+  View profile credentials
+
+  USAGE
+
+    symbol-cli profile decrypt [...options]
+
+  OPTIONS
+
+    --profile <profile> - (Optional) Select between your profiles, by providing a profile name.
+
+
+### import
+
+Failed to initialize libusb.
+
+  Create a new profile with existing private key
+
+  USAGE
+
+    symbol-cli profile import [...options]
+
+  OPTIONS
+
+    --profile <profile>                      - (Optional) Select between your profiles, by providing a profile name.                                                                                                 
+    --hd                                     - (Optional) Create an HD wallet.                                                                                                                                       
+    --ledger                                 - (Optional) Create an Ledger wallet.                                                                                                                                   
+    -u, --url <url>                          - (Optional) When saving profile, provide a Symbol Node URL. Example: http://localhost:3000                                                                             
+    -n, --network <network>                  - (Optional) Network Type. (MAIN_NET, TEST_NET)                                                                                                                         
+    -p, --password <password>                - (Optional) When saving profile, provide the password.                                                                                                                 
+    -d, --default                            - (Optional) Set the profile as default.                                                                                                                                
+    -g, --generation-hash <generationHash>   - (Optional) Generation hash of the network. Required to create the profile offline.                                                                                    
+    -i, --namespace-id <namespaceId>         - (Optional) Namespace Name of the network mosaic. (eg.: symbol.xym) Required to create the profile offline.                                                            
+    -v, --divisibility <divisibility>        - (Optional) Divisibility of the network mosaic. (eg.: 6) Required to create the profile offline.                                                                       
+    -e, --epoch-adjustment <epochAdjustment> - (Optional) The epoch adjustment network configuration in seconds used to created the transaction`s deadline. (eg.: 1573430400) Required to create the profile offline.
+    -P, --private-key <privateKey>           - Account private key.                                                                                                                                                  
+    -M, --mnemonic <mnemonic>                - (Optional) Import a profile using a mnemonic.                                                                                                                         
+    -N, --path-number <pathNumber>           - (Optional) HD wallet path number.                                                                                                                                     
+    -O, --optin                              - (Optional) Whether it is an Opt-in account. (Default: false)                                                                                                          
+
+
+### list
+
+Failed to initialize libusb.
+
+  Display the list of stored profiles
+
+  USAGE
+
+    symbol-cli profile list [...options]
+
+  OPTIONS
+
+    --profile <profile> - (Optional) Select between your profiles, by providing a profile name.
+
+
+### setdefault
+
+Failed to initialize libusb.
+
+  Change the default profile
+
+  USAGE
+
+    symbol-cli profile setdefault [...options]
+
+  OPTIONS
+
+    --profile <profile> - (Optional) Select between your profiles, by providing a profile name.
+
+
+## Restriction
+
+### account
+
+Failed to initialize libusb.
+
+  Fetch account restrictions assigned to an address
+
+  USAGE
+
+    symbol-cli restriction account [...options]
+
+  OPTIONS
+
+    --profile <profile>     - (Optional) Select between your profiles, by providing a profile name.
+    -a, --address <address> - Account address.                                                     
+
+
+### mosaicaddress
+
+Failed to initialize libusb.
+
+  Fetch mosaic restrictions assigned to an address
+
+  USAGE
+
+    symbol-cli restriction mosaicaddress [...options]
+
+  OPTIONS
+
+    --profile <profile>        - (Optional) Select between your profiles, by providing a profile name.
+    -a, --address <address>    - Account address.                                                     
+    -m, --mosaic-id <mosaicId> - Mosaic id in hexadecimal format.                                     
+
+
+### mosaicglobal
+
+Failed to initialize libusb.
+
+  Fetch global restrictions assigned to a mosaic
+
+  USAGE
+
+    symbol-cli restriction mosaicglobal [...options]
+
+  OPTIONS
+
+    --profile <profile>        - (Optional) Select between your profiles, by providing a profile name.
+    -m, --mosaic-id <mosaicId> - Mosaic id in hexadecimal format.                                     
+
+
+## Transaction
+
+### search
+
+Failed to initialize libusb.
+
+  Search transactions
+
+  USAGE
+
+    symbol-cli transaction search [...options]
+
+  OPTIONS
+
+    --profile <profile>                    - (Optional) Select between your profiles, by providing a profile name.                
+    -o, --order <order>                    - (Optional): Sort entries. (Desc: Newer to older, Asc: Older to newer) [Desc]         
+    -n, --page-size <pageSize>             - (Optional) Number of entries per page. [10]                                          
+    -n, --page-number <pageNumber>         - (Optional) Filter by page number. [1]                                                
+    -i, --offset <offset>                  - (Optional) Database entry id at which to start pagination.                           
+    --group <group>                        - (Optional) Filter by transaction group. (Confirmed, Unconfirmed, Partial) [Confirmed]
+    --address <address>                    - (Optional) Filter by address involved in the transaction.                            
+    --recipient-address <recipientAddress> - (Optional) Filter by address of an account receiving the transaction.                
+    --signer-public-key <signerPublicKey>  - (Optional) Public key of the account signing the entity.                             
+    --height <height>                      - (Optional) Filter by block height.                                                   
+    --type <type>                          - (Optional) Filter by transaction type. (E.g. TRANSFER)                               
+    --from-height <fromHeight>             - (Optional) Filter by block height range ("from").                                    
+    --to-height <toHeight>                 - (Optional) Filter by block height range ("to").                                      
+
+
+### info
+
+Failed to initialize libusb.
+
+  Fetch transaction info
+
+  USAGE
+
+    symbol-cli transaction info [...options]
+
+  OPTIONS
+
+    --profile <profile> - (Optional) Select between your profiles, by providing a profile name.
+    -h, --hash <hash>   - Transaction hash.                                                    
+
+
+### status
+
+Failed to initialize libusb.
+
+  Fetch transaction status
+
+  USAGE
+
+    symbol-cli transaction status [...options]
+
+  OPTIONS
+
+    --profile <profile> - (Optional) Select between your profiles, by providing a profile name.
+    -h, --hash <hash>   - Transaction hash.                                                    
+
+
+### uri
+
+Failed to initialize libusb.
+
+  Announce transaction from URI
+
+  USAGE
+
+    symbol-cli transaction uri [...options]
+
+  OPTIONS
+
+    --profile <profile>                      - (Optional) Select between your profiles, by providing a profile name.                                
+    -p, --password <password>                - Profile password.                                                                                    
+    -f, --max-fee <maxFee>                   - Maximum fee (absolute amount).                                                                       
+    --sync                                   - (Optional) Wait until the server confirms or rejects the transaction.                                
+    --announce                               - (Optional) Announce the transaction without double confirmation.                                     
+    -M, --mode <mode>                        - Transaction announcement mode (normal, multisig)                                                     
+    -S, --signer <signer>                    - (Multisig only) Transaction signer public key                                                        
+    -F, --max-fee-hash-lock <maxFeeHashLock> - (Multisig aggregate bonded only) Maximum fee (absolute amount) to announce the hash lock transaction.
+    -D, --lock-duration <lockDuration>       - (Multisig aggregate bonded only) Hash lock duration expressed in blocks. [480]                       
+    -L, --lock-amount <lockAmount>           - (Multisig aggregate bonded only) Relative amount of network mosaic to lock. [10]                     
+    -u, --uri <uri>                          - Transaction URI.                                                                                     
+
+
+### accountaddressrestriction
+
+Failed to initialize libusb.
+
+  Allow or block incoming and outgoing transactions for a given a set of addresses
+
+  USAGE
+
+    symbol-cli transaction accountaddressrestriction [...options]
+
+  OPTIONS
+
+    --profile <profile>                        - (Optional) Select between your profiles, by providing a profile name.                                     
+    -p, --password <password>                  - Profile password.                                                                                         
+    -f, --max-fee <maxFee>                     - Maximum fee (absolute amount).                                                                            
+    --sync                                     - (Optional) Wait until the server confirms or rejects the transaction.                                     
+    --announce                                 - (Optional) Announce the transaction without double confirmation.                                          
+    -M, --mode <mode>                          - Transaction announcement mode (normal, multisig)                                                          
+    -S, --signer <signer>                      - (Multisig only) Transaction signer public key                                                             
+    -F, --max-fee-hash-lock <maxFeeHashLock>   - (Multisig aggregate bonded only) Maximum fee (absolute amount) to announce the hash lock transaction.     
+    -D, --lock-duration <lockDuration>         - (Multisig aggregate bonded only) Hash lock duration expressed in blocks. [480]                            
+    -L, --lock-amount <lockAmount>             - (Multisig aggregate bonded only) Relative amount of network mosaic to lock. [10]                          
+    -f, --flags <flags>                        - Restriction flags.(AllowOutgoingAddress, BlockOutgoingAddress, AllowIncomingAddress, BlockIncomingAddress)
+    -a, --action <action>                      - Modification action. (Add, Remove).                                                                       
+    -v, --recipient-address <recipientAddress> - Address or @alias to allow/block.                                                                         
+
+
+### accountkeylink
+
+Failed to initialize libusb.
+
+  Delegate the account importance to a proxy account. Required for all accounts willing to activate delegated harvesting.
+
+  USAGE
+
+    symbol-cli transaction accountkeylink [...options]
+
+  OPTIONS
+
+    --profile <profile>                       - (Optional) Select between your profiles, by providing a profile name.                                
+    -p, --password <password>                 - Profile password.                                                                                    
+    -f, --max-fee <maxFee>                    - Maximum fee (absolute amount).                                                                       
+    --sync                                    - (Optional) Wait until the server confirms or rejects the transaction.                                
+    --announce                                - (Optional) Announce the transaction without double confirmation.                                     
+    -M, --mode <mode>                         - Transaction announcement mode (normal, multisig)                                                     
+    -S, --signer <signer>                     - (Multisig only) Transaction signer public key                                                        
+    -F, --max-fee-hash-lock <maxFeeHashLock>  - (Multisig aggregate bonded only) Maximum fee (absolute amount) to announce the hash lock transaction.
+    -D, --lock-duration <lockDuration>        - (Multisig aggregate bonded only) Hash lock duration expressed in blocks. [480]                       
+    -L, --lock-amount <lockAmount>            - (Multisig aggregate bonded only) Relative amount of network mosaic to lock. [10]                     
+    -u, --linked-public-key <linkedPublicKey> - Linked Public Key.                                                                                   
+    -a, --action <action>                     - Alias action (Link, Unlink).                                                                         
+
+
+### accountmetadata
+
+Failed to initialize libusb.
+
+  Add custom data to an account (requires internet)
+
+  USAGE
+
+    symbol-cli transaction accountmetadata [...options]
+
+  OPTIONS
+
+    --profile <profile>                      - (Optional) Select between your profiles, by providing a profile name.                                
+    -p, --password <password>                - Profile password.                                                                                    
+    -f, --max-fee <maxFee>                   - Maximum fee (absolute amount).                                                                       
+    --sync                                   - (Optional) Wait until the server confirms or rejects the transaction.                                
+    --announce                               - (Optional) Announce the transaction without double confirmation.                                     
+    -M, --mode <mode>                        - Transaction announcement mode (normal, multisig)                                                     
+    -S, --signer <signer>                    - (Multisig only) Transaction signer public key                                                        
+    -F, --max-fee-hash-lock <maxFeeHashLock> - (Multisig aggregate bonded only) Maximum fee (absolute amount) to announce the hash lock transaction.
+    -D, --lock-duration <lockDuration>       - (Multisig aggregate bonded only) Hash lock duration expressed in blocks. [480]                       
+    -L, --lock-amount <lockAmount>           - (Multisig aggregate bonded only) Relative amount of network mosaic to lock. [10]                     
+    -t, --target-address <targetAddress>     - Metadata target address.                                                                             
+    -k, --key <key>                          - Metadata key (UInt64) in hexadecimal format.                                                         
+    -v, --value <value>                      - Metadata value.                                                                                      
+
+
+### accountmosaicrestriction
+
+Failed to initialize libusb.
+
+  Allow or block incoming transactions containing a given set of mosaics
+
+  USAGE
+
+    symbol-cli transaction accountmosaicrestriction [...options]
+
+  OPTIONS
+
+    --profile <profile>                      - (Optional) Select between your profiles, by providing a profile name.                                
+    -p, --password <password>                - Profile password.                                                                                    
+    -f, --max-fee <maxFee>                   - Maximum fee (absolute amount).                                                                       
+    --sync                                   - (Optional) Wait until the server confirms or rejects the transaction.                                
+    --announce                               - (Optional) Announce the transaction without double confirmation.                                     
+    -M, --mode <mode>                        - Transaction announcement mode (normal, multisig)                                                     
+    -S, --signer <signer>                    - (Multisig only) Transaction signer public key                                                        
+    -F, --max-fee-hash-lock <maxFeeHashLock> - (Multisig aggregate bonded only) Maximum fee (absolute amount) to announce the hash lock transaction.
+    -D, --lock-duration <lockDuration>       - (Multisig aggregate bonded only) Hash lock duration expressed in blocks. [480]                       
+    -L, --lock-amount <lockAmount>           - (Multisig aggregate bonded only) Relative amount of network mosaic to lock. [10]                     
+    -f, --flags <flags>                      - Restriction flags.(AllowMosaic,BlockMosaic)                                                          
+    -a, --action <action>                    - Modification action. (Add, Remove).                                                                  
+    -v, --mosaic-id <mosaicId>               - Mosaic or @alias to allow / block.                                                                   
+
+
+### accountoperationrestriction
+
+Failed to initialize libusb.
+
+  Allow or block outgoing transactions by transaction type
+
+  USAGE
+
+    symbol-cli transaction accountoperationrestriction [...options]
+
+  OPTIONS
+
+    --profile <profile>                      - (Optional) Select between your profiles, by providing a profile name.                                
+    -p, --password <password>                - Profile password.                                                                                    
+    -f, --max-fee <maxFee>                   - Maximum fee (absolute amount).                                                                       
+    --sync                                   - (Optional) Wait until the server confirms or rejects the transaction.                                
+    --announce                               - (Optional) Announce the transaction without double confirmation.                                     
+    -M, --mode <mode>                        - Transaction announcement mode (normal, multisig)                                                     
+    -S, --signer <signer>                    - (Multisig only) Transaction signer public key                                                        
+    -F, --max-fee-hash-lock <maxFeeHashLock> - (Multisig aggregate bonded only) Maximum fee (absolute amount) to announce the hash lock transaction.
+    -D, --lock-duration <lockDuration>       - (Multisig aggregate bonded only) Hash lock duration expressed in blocks. [480]                       
+    -L, --lock-amount <lockAmount>           - (Multisig aggregate bonded only) Relative amount of network mosaic to lock. [10]                     
+    -f, --flags <flags>                      - Restriction flag. (AllowOutgoingTransactionType,BlockOutgoingTransactionType)                        
+    -a, --action <action>                    - Modification action. (Add, Remove).                                                                  
+    -v, --transaction-type <transactionType> - Transaction type formatted as hex.                                                                   
+
+
+### addressalias
+
+Failed to initialize libusb.
+
+  Set an alias to an address
+
+  USAGE
+
+    symbol-cli transaction addressalias [...options]
+
+  OPTIONS
+
+    --profile <profile>                      - (Optional) Select between your profiles, by providing a profile name.                                
+    -p, --password <password>                - Profile password.                                                                                    
+    -f, --max-fee <maxFee>                   - Maximum fee (absolute amount).                                                                       
+    --sync                                   - (Optional) Wait until the server confirms or rejects the transaction.                                
+    --announce                               - (Optional) Announce the transaction without double confirmation.                                     
+    -M, --mode <mode>                        - Transaction announcement mode (normal, multisig)                                                     
+    -S, --signer <signer>                    - (Multisig only) Transaction signer public key                                                        
+    -F, --max-fee-hash-lock <maxFeeHashLock> - (Multisig aggregate bonded only) Maximum fee (absolute amount) to announce the hash lock transaction.
+    -D, --lock-duration <lockDuration>       - (Multisig aggregate bonded only) Hash lock duration expressed in blocks. [480]                       
+    -L, --lock-amount <lockAmount>           - (Multisig aggregate bonded only) Relative amount of network mosaic to lock. [10]                     
+    -a, --action <action>                    - Alias action (Link, Unlink).                                                                         
+    -a, --address <address>                  - Account address.                                                                                     
+    -n, --namespace-name <namespaceName>     - Namespace name.                                                                                      
+
+
+### cosign
+
+Failed to initialize libusb.
+
+  Cosign an aggregate bonded transaction
+
+  USAGE
+
+    symbol-cli transaction cosign [...options]
+
+  OPTIONS
+
+    --profile <profile>                                 - (Optional) Select between your profiles, by providing a profile name.                                
+    -p, --password <password>                           - Profile password.                                                                                    
+    -f, --max-fee <maxFee>                              - Maximum fee (absolute amount).                                                                       
+    --sync                                              - (Optional) Wait until the server confirms or rejects the transaction.                                
+    --announce                                          - (Optional) Announce the transaction without double confirmation.                                     
+    -M, --mode <mode>                                   - Transaction announcement mode (normal, multisig)                                                     
+    -S, --signer <signer>                               - (Multisig only) Transaction signer public key                                                        
+    -F, --max-fee-hash-lock <maxFeeHashLock>            - (Multisig aggregate bonded only) Maximum fee (absolute amount) to announce the hash lock transaction.
+    -D, --lock-duration <lockDuration>                  - (Multisig aggregate bonded only) Hash lock duration expressed in blocks. [480]                       
+    -L, --lock-amount <lockAmount>                      - (Multisig aggregate bonded only) Relative amount of network mosaic to lock. [10]                     
+    -i, --transaction-input-type <transactionInputType> - Transaction input type (hash or payload).                                                            
+    -h, --hash <hash>                                   - Aggregate bonded transaction hash to be signed.                                                      
+    -p, --payload <payload>                             - Aggregate transaction payload to be signed (hex string).                                             
+
+
+### mosaic
+
+Failed to initialize libusb.
+
+  Create a new mosaic
+
+  USAGE
+
+    symbol-cli transaction mosaic [...options]
+
+  OPTIONS
+
+    --profile <profile>                      - (Optional) Select between your profiles, by providing a profile name.                                
+    -p, --password <password>                - Profile password.                                                                                    
+    -f, --max-fee <maxFee>                   - Maximum fee (absolute amount).                                                                       
+    --sync                                   - (Optional) Wait until the server confirms or rejects the transaction.                                
+    --announce                               - (Optional) Announce the transaction without double confirmation.                                     
+    -M, --mode <mode>                        - Transaction announcement mode (normal, multisig)                                                     
+    -S, --signer <signer>                    - (Multisig only) Transaction signer public key                                                        
+    -F, --max-fee-hash-lock <maxFeeHashLock> - (Multisig aggregate bonded only) Maximum fee (absolute amount) to announce the hash lock transaction.
+    -D, --lock-duration <lockDuration>       - (Multisig aggregate bonded only) Hash lock duration expressed in blocks. [480]                       
+    -L, --lock-amount <lockAmount>           - (Multisig aggregate bonded only) Relative amount of network mosaic to lock. [10]                     
+    -a, --amount <amount>                    - Initial supply of mosaics.                                                                           
+    -t, --transferable                       - (Optional) Mosaic transferable.                                                                      
+    -s, --supply-mutable                     - (Optional) Mosaic supply mutable.                                                                    
+    -r, --restrictable                       - (Optional) Mosaic restrictable.                                                                      
+    -d, --divisibility <divisibility>        - Mosaic divisibility, from 0 to 6.                                                                    
+    -u, --duration <duration>                - Mosaic duration in amount of blocks.                                                                 
+    -n, --non-expiring                       - (Optional) Mosaic non-expiring.                                                                      
+
+
+### mosaicaddressrestriction
+
+Failed to initialize libusb.
+
+  Set a mosaic restriction to an specific address (requires internet)
+
+  USAGE
+
+    symbol-cli transaction mosaicaddressrestriction [...options]
+
+  OPTIONS
+
+    --profile <profile>                               - (Optional) Select between your profiles, by providing a profile name.                                
+    -p, --password <password>                         - Profile password.                                                                                    
+    -f, --max-fee <maxFee>                            - Maximum fee (absolute amount).                                                                       
+    --sync                                            - (Optional) Wait until the server confirms or rejects the transaction.                                
+    --announce                                        - (Optional) Announce the transaction without double confirmation.                                     
+    -M, --mode <mode>                                 - Transaction announcement mode (normal, multisig)                                                     
+    -S, --signer <signer>                             - (Multisig only) Transaction signer public key                                                        
+    -F, --max-fee-hash-lock <maxFeeHashLock>          - (Multisig aggregate bonded only) Maximum fee (absolute amount) to announce the hash lock transaction.
+    -D, --lock-duration <lockDuration>                - (Multisig aggregate bonded only) Hash lock duration expressed in blocks. [480]                       
+    -L, --lock-amount <lockAmount>                    - (Multisig aggregate bonded only) Relative amount of network mosaic to lock. [10]                     
+    -m, --mosaic-id <mosaicId>                        - Mosaic identifier or @alias being restricted.                                                        
+    -a, --target-address <targetAddress>              - Address or @alias being restricted.                                                                  
+    -k, --restriction-key <restrictionKey>            - Restriction key.                                                                                     
+    -V, --new-restriction-value <newRestrictionValue> - New restriction value.                                                                               
+
+
+### mosaicalias
+
+Failed to initialize libusb.
+
+  Set an alias to a mosaic
+
+  USAGE
+
+    symbol-cli transaction mosaicalias [...options]
+
+  OPTIONS
+
+    --profile <profile>                      - (Optional) Select between your profiles, by providing a profile name.                                
+    -p, --password <password>                - Profile password.                                                                                    
+    -f, --max-fee <maxFee>                   - Maximum fee (absolute amount).                                                                       
+    --sync                                   - (Optional) Wait until the server confirms or rejects the transaction.                                
+    --announce                               - (Optional) Announce the transaction without double confirmation.                                     
+    -M, --mode <mode>                        - Transaction announcement mode (normal, multisig)                                                     
+    -S, --signer <signer>                    - (Multisig only) Transaction signer public key                                                        
+    -F, --max-fee-hash-lock <maxFeeHashLock> - (Multisig aggregate bonded only) Maximum fee (absolute amount) to announce the hash lock transaction.
+    -D, --lock-duration <lockDuration>       - (Multisig aggregate bonded only) Hash lock duration expressed in blocks. [480]                       
+    -L, --lock-amount <lockAmount>           - (Multisig aggregate bonded only) Relative amount of network mosaic to lock. [10]                     
+    -a, --action <action>                    - Alias action (Link, Unlink).                                                                         
+    -m, --mosaic-id <mosaicId>               - Mosaic id in hexadecimal format.                                                                     
+    -n, --namespace-name <namespaceName>     - Namespace name.                                                                                      
+
+
+### mosaicglobalrestriction
+
+Failed to initialize libusb.
+
+  Set a global restriction to a mosaic (requires internet)
+
+  USAGE
+
+    symbol-cli transaction mosaicglobalrestriction [...options]
+
+  OPTIONS
+
+    --profile <profile>                               - (Optional) Select between your profiles, by providing a profile name.                                
+    -p, --password <password>                         - Profile password.                                                                                    
+    -f, --max-fee <maxFee>                            - Maximum fee (absolute amount).                                                                       
+    --sync                                            - (Optional) Wait until the server confirms or rejects the transaction.                                
+    --announce                                        - (Optional) Announce the transaction without double confirmation.                                     
+    -M, --mode <mode>                                 - Transaction announcement mode (normal, multisig)                                                     
+    -S, --signer <signer>                             - (Multisig only) Transaction signer public key                                                        
+    -F, --max-fee-hash-lock <maxFeeHashLock>          - (Multisig aggregate bonded only) Maximum fee (absolute amount) to announce the hash lock transaction.
+    -D, --lock-duration <lockDuration>                - (Multisig aggregate bonded only) Hash lock duration expressed in blocks. [480]                       
+    -L, --lock-amount <lockAmount>                    - (Multisig aggregate bonded only) Relative amount of network mosaic to lock. [10]                     
+    -m, --mosaic-id <mosaicId>                        - Mosaic identifier or @alias being restricted.                                                        
+    -r, --reference-mosaic-id <referenceMosaicId>     - (Optional) Identifier of the mosaic providing the restriction key. [0000000000000000]                
+    -k, --restriction-key <restrictionKey>            - Restriction key relative to the reference mosaic identifier.                                         
+    -V, --new-restriction-value <newRestrictionValue> - New restriction value.                                                                               
+    -T, --new-restriction-type <newRestrictionType>   - New restriction type. (NONE, EQ, GE, GT, LE, LT, NE)                                                 
+
+
+### mosaicmetadata
+
+Failed to initialize libusb.
+
+  Add custom data to a mosaic (requires internet)
+
+  USAGE
+
+    symbol-cli transaction mosaicmetadata [...options]
+
+  OPTIONS
+
+    --profile <profile>                      - (Optional) Select between your profiles, by providing a profile name.                                
+    -p, --password <password>                - Profile password.                                                                                    
+    -f, --max-fee <maxFee>                   - Maximum fee (absolute amount).                                                                       
+    --sync                                   - (Optional) Wait until the server confirms or rejects the transaction.                                
+    --announce                               - (Optional) Announce the transaction without double confirmation.                                     
+    -M, --mode <mode>                        - Transaction announcement mode (normal, multisig)                                                     
+    -S, --signer <signer>                    - (Multisig only) Transaction signer public key                                                        
+    -F, --max-fee-hash-lock <maxFeeHashLock> - (Multisig aggregate bonded only) Maximum fee (absolute amount) to announce the hash lock transaction.
+    -D, --lock-duration <lockDuration>       - (Multisig aggregate bonded only) Hash lock duration expressed in blocks. [480]                       
+    -L, --lock-amount <lockAmount>           - (Multisig aggregate bonded only) Relative amount of network mosaic to lock. [10]                     
+    -m, --mosaic-id <mosaicId>               - Mosaic id be assigned metadata in hexadecimal format.                                                
+    -t, --target-address <targetAddress>     - Mosaic id owner account address.                                                                     
+    -k, --key <key>                          - Metadata key (UInt64) in hexadecimal format.                                                         
+    -v, --value <value>                      - Value of metadata key.                                                                               
+
+
+### mosaicsupplychange
+
+Failed to initialize libusb.
+
+  Change a mosaic supply
+
+  USAGE
+
+    symbol-cli transaction mosaicsupplychange [...options]
+
+  OPTIONS
+
+    --profile <profile>                      - (Optional) Select between your profiles, by providing a profile name.                                
+    -p, --password <password>                - Profile password.                                                                                    
+    -f, --max-fee <maxFee>                   - Maximum fee (absolute amount).                                                                       
+    --sync                                   - (Optional) Wait until the server confirms or rejects the transaction.                                
+    --announce                               - (Optional) Announce the transaction without double confirmation.                                     
+    -M, --mode <mode>                        - Transaction announcement mode (normal, multisig)                                                     
+    -S, --signer <signer>                    - (Multisig only) Transaction signer public key                                                        
+    -F, --max-fee-hash-lock <maxFeeHashLock> - (Multisig aggregate bonded only) Maximum fee (absolute amount) to announce the hash lock transaction.
+    -D, --lock-duration <lockDuration>       - (Multisig aggregate bonded only) Hash lock duration expressed in blocks. [480]                       
+    -L, --lock-amount <lockAmount>           - (Multisig aggregate bonded only) Relative amount of network mosaic to lock. [10]                     
+    -a, --action <action>                    - Mosaic supply change action (Increase, Decrease).                                                    
+    -m, --mosaic-id <mosaicId>               - Mosaic id in hexadecimal format.                                                                     
+    -d, --amount <amount>                    - Atomic amount of supply change.                                                                      
+
+
+### multisigmodification
+
+Failed to initialize libusb.
+
+  Create or modify a multisig account
+
+  USAGE
+
+    symbol-cli transaction multisigmodification [...options]
+
+  OPTIONS
+
+    --profile <profile>                                          - (Optional) Select between your profiles, by providing a profile name.                                                                        
+    -p, --password <password>                                    - Profile password.                                                                                                                            
+    -f, --max-fee <maxFee>                                       - Maximum fee (absolute amount).                                                                                                               
+    --sync                                                       - (Optional) Wait until the server confirms or rejects the transaction.                                                                        
+    --announce                                                   - (Optional) Announce the transaction without double confirmation.                                                                             
+    -M, --mode <mode>                                            - Transaction announcement mode (normal, multisig)                                                                                             
+    -S, --signer <signer>                                        - (Multisig only) Transaction signer public key                                                                                                
+    -F, --max-fee-hash-lock <maxFeeHashLock>                     - (Multisig aggregate bonded only) Maximum fee (absolute amount) to announce the hash lock transaction.                                        
+    -D, --lock-duration <lockDuration>                           - (Multisig aggregate bonded only) Hash lock duration expressed in blocks. [480]                                                               
+    -L, --lock-amount <lockAmount>                               - (Multisig aggregate bonded only) Relative amount of network mosaic to lock. [10]                                                             
+    -R, --min-removal-delta <minRemovalDelta>                    - Number of signatures needed to remove a cosignatory. If the account is already multisig, enter the number of cosignatories to add or remove. 
+    -A, --min-approval-delta <minApprovalDelta>                  - Number of signatures needed to approve a transaction. If the account is already multisig, enter the number of cosignatories to add or remove.
+    -a, --action <action>                                        - Modification Action (Add, Remove).                                                                                                           
+    -p, --cosignatory-addresses <cosignatoryAddresses>           - Cosignatory accounts addresses (separated by a comma).                                                                                       
+    -u, --multisig-account-public-key <multisigAccountPublicKey> - Multisig account public key.                                                                                                                 
+    -t, --aggregate-type <aggregateType>                         - Aggregate Type (complete or bonded)                                                                                                          
+    -d, --deadline <deadline>                                    - Deadline (milliseconds since Nemesis block)                                                                                                  
+
+
+### namespace
+
+Failed to initialize libusb.
+
+  Register a namespace
+
+  USAGE
+
+    symbol-cli transaction namespace [...options]
+
+  OPTIONS
+
+    --profile <profile>                      - (Optional) Select between your profiles, by providing a profile name.                                
+    -p, --password <password>                - Profile password.                                                                                    
+    -f, --max-fee <maxFee>                   - Maximum fee (absolute amount).                                                                       
+    --sync                                   - (Optional) Wait until the server confirms or rejects the transaction.                                
+    --announce                               - (Optional) Announce the transaction without double confirmation.                                     
+    -M, --mode <mode>                        - Transaction announcement mode (normal, multisig)                                                     
+    -S, --signer <signer>                    - (Multisig only) Transaction signer public key                                                        
+    -F, --max-fee-hash-lock <maxFeeHashLock> - (Multisig aggregate bonded only) Maximum fee (absolute amount) to announce the hash lock transaction.
+    -D, --lock-duration <lockDuration>       - (Multisig aggregate bonded only) Hash lock duration expressed in blocks. [480]                       
+    -L, --lock-amount <lockAmount>           - (Multisig aggregate bonded only) Relative amount of network mosaic to lock. [10]                     
+    -n, --name <name>                        - Namespace name.                                                                                      
+    -r, --rootnamespace                      - Root namespace.                                                                                      
+    -s, --subnamespace                       - Sub namespace.                                                                                       
+    -d, --duration <duration>                - Duration (use it with --rootnamespace).                                                              
+    -a, --parent-name <parentName>           - Parent namespace name (use it with --subnamespace).                                                  
+
+
+### namespacemetadata
+
+Failed to initialize libusb.
+
+  Add custom data to a namespace (requires internet)
+
+  USAGE
+
+    symbol-cli transaction namespacemetadata [...options]
+
+  OPTIONS
+
+    --profile <profile>                      - (Optional) Select between your profiles, by providing a profile name.                                
+    -p, --password <password>                - Profile password.                                                                                    
+    -f, --max-fee <maxFee>                   - Maximum fee (absolute amount).                                                                       
+    --sync                                   - (Optional) Wait until the server confirms or rejects the transaction.                                
+    --announce                               - (Optional) Announce the transaction without double confirmation.                                     
+    -M, --mode <mode>                        - Transaction announcement mode (normal, multisig)                                                     
+    -S, --signer <signer>                    - (Multisig only) Transaction signer public key                                                        
+    -F, --max-fee-hash-lock <maxFeeHashLock> - (Multisig aggregate bonded only) Maximum fee (absolute amount) to announce the hash lock transaction.
+    -D, --lock-duration <lockDuration>       - (Multisig aggregate bonded only) Hash lock duration expressed in blocks. [480]                       
+    -L, --lock-amount <lockAmount>           - (Multisig aggregate bonded only) Relative amount of network mosaic to lock. [10]                     
+    -n, --namespace-id <namespaceId>         - Mosaic id be assigned metadata in hexadecimal format.                                                
+    -t, --target-address <targetAddress>     - Namespace id owner account address.                                                                  
+    -k, --key <key>                          - Key of metadata.                                                                                     
+    -v, --value <value>                      - Metadata key (UInt64) in hexadecimal format.                                                         
+
+
+### nodekeylink
+
+Failed to initialize libusb.
+
+  Link an account with a public key used by TLS to create sessions. Required for node operators.
+
+  USAGE
+
+    symbol-cli transaction nodekeylink [...options]
+
+  OPTIONS
+
+    --profile <profile>                       - (Optional) Select between your profiles, by providing a profile name.                                
+    -p, --password <password>                 - Profile password.                                                                                    
+    -f, --max-fee <maxFee>                    - Maximum fee (absolute amount).                                                                       
+    --sync                                    - (Optional) Wait until the server confirms or rejects the transaction.                                
+    --announce                                - (Optional) Announce the transaction without double confirmation.                                     
+    -M, --mode <mode>                         - Transaction announcement mode (normal, multisig)                                                     
+    -S, --signer <signer>                     - (Multisig only) Transaction signer public key                                                        
+    -F, --max-fee-hash-lock <maxFeeHashLock>  - (Multisig aggregate bonded only) Maximum fee (absolute amount) to announce the hash lock transaction.
+    -D, --lock-duration <lockDuration>        - (Multisig aggregate bonded only) Hash lock duration expressed in blocks. [480]                       
+    -L, --lock-amount <lockAmount>            - (Multisig aggregate bonded only) Relative amount of network mosaic to lock. [10]                     
+    -u, --linked-public-key <linkedPublicKey> - Linked Public Key.                                                                                   
+    -a, --action <action>                     - Alias action (Link, Unlink).                                                                         
+
+
+### persistentharvestdelegation
+
+Failed to initialize libusb.
+
+  Requests a node to add a remote account as a delegated harvester
+
+  USAGE
+
+    symbol-cli transaction persistentharvestdelegation [...options]
+
+  OPTIONS
+
+    --profile <profile>                             - (Optional) Select between your profiles, by providing a profile name.                                
+    -p, --password <password>                       - Profile password.                                                                                    
+    -f, --max-fee <maxFee>                          - Maximum fee (absolute amount).                                                                       
+    --sync                                          - (Optional) Wait until the server confirms or rejects the transaction.                                
+    --announce                                      - (Optional) Announce the transaction without double confirmation.                                     
+    -M, --mode <mode>                               - Transaction announcement mode (normal, multisig)                                                     
+    -S, --signer <signer>                           - (Multisig only) Transaction signer public key                                                        
+    -F, --max-fee-hash-lock <maxFeeHashLock>        - (Multisig aggregate bonded only) Maximum fee (absolute amount) to announce the hash lock transaction.
+    -D, --lock-duration <lockDuration>              - (Multisig aggregate bonded only) Hash lock duration expressed in blocks. [480]                       
+    -L, --lock-amount <lockAmount>                  - (Multisig aggregate bonded only) Relative amount of network mosaic to lock. [10]                     
+    -r, --remote-private-key <remotePrivateKey>     - Private key of the remote account.                                                                   
+    -u, --recipient-public-key <recipientPublicKey> - Public key of the node to request persistent harvesting delegation.                                  
+    -v, --vrf-private-key <vrfPrivateKey>           - VRF Private key linked to the main account.                                                          
+
+
+### secretlock
+
+Failed to initialize libusb.
+
+  Announce a secret lock transaction
+
+  USAGE
+
+    symbol-cli transaction secretlock [...options]
+
+  OPTIONS
+
+    --profile <profile>                        - (Optional) Select between your profiles, by providing a profile name.                                                                                  
+    -p, --password <password>                  - Profile password.                                                                                                                                      
+    -f, --max-fee <maxFee>                     - Maximum fee (absolute amount).                                                                                                                         
+    --sync                                     - (Optional) Wait until the server confirms or rejects the transaction.                                                                                  
+    --announce                                 - (Optional) Announce the transaction without double confirmation.                                                                                       
+    -M, --mode <mode>                          - Transaction announcement mode (normal, multisig)                                                                                                       
+    -S, --signer <signer>                      - (Multisig only) Transaction signer public key                                                                                                          
+    -F, --max-fee-hash-lock <maxFeeHashLock>   - (Multisig aggregate bonded only) Maximum fee (absolute amount) to announce the hash lock transaction.                                                  
+    -D, --lock-duration <lockDuration>         - (Multisig aggregate bonded only) Hash lock duration expressed in blocks. [480]                                                                         
+    -L, --lock-amount <lockAmount>             - (Multisig aggregate bonded only) Relative amount of network mosaic to lock. [10]                                                                       
+    -m, --mosaic-id <mosaicId>                 - Locked mosaic identifier or @alias.                                                                                                                    
+    -a, --amount <amount>                      - Amount of mosaic units to lock.                                                                                                                        
+    -d, --duration <duration>                  - Number of blocks for which a lock should be valid. Duration is allowed to lie up to 30 days. If reached, the mosaics will be returned to the initiator.
+    -s, --secret <secret>                      - Proof hashed in hexadecimal format.                                                                                                                    
+    -H, --hash-algorithm <hashAlgorithm>       - Algorithm used to hash the proof (Op_Sha3_256, Op_Hash_160, Op_Hash_256).                                                                              
+    -r, --recipient-address <recipientAddress> - Address or @alias that receives the funds once unlocked.                                                                                               
+
+
+### secretproof
+
+Failed to initialize libusb.
+
+  Announce a secret proof transaction
+
+  USAGE
+
+    symbol-cli transaction secretproof [...options]
+
+  OPTIONS
+
+    --profile <profile>                        - (Optional) Select between your profiles, by providing a profile name.                                
+    -p, --password <password>                  - Profile password.                                                                                    
+    -f, --max-fee <maxFee>                     - Maximum fee (absolute amount).                                                                       
+    --sync                                     - (Optional) Wait until the server confirms or rejects the transaction.                                
+    --announce                                 - (Optional) Announce the transaction without double confirmation.                                     
+    -M, --mode <mode>                          - Transaction announcement mode (normal, multisig)                                                     
+    -S, --signer <signer>                      - (Multisig only) Transaction signer public key                                                        
+    -F, --max-fee-hash-lock <maxFeeHashLock>   - (Multisig aggregate bonded only) Maximum fee (absolute amount) to announce the hash lock transaction.
+    -D, --lock-duration <lockDuration>         - (Multisig aggregate bonded only) Hash lock duration expressed in blocks. [480]                       
+    -L, --lock-amount <lockAmount>             - (Multisig aggregate bonded only) Relative amount of network mosaic to lock. [10]                     
+    -s, --secret <secret>                      - Proof hashed in hexadecimal.                                                                         
+    -p, --proof <proof>                        - Original random set of bytes in hexadecimal.                                                         
+    -H, --hash-algorithm <hashAlgorithm>       - Algorithm used to hash the proof (Op_Sha3_256, Op_Hash_160, Op_Hash_256).                            
+    -r, --recipient-address <recipientAddress> - Address or @alias that receives the funds once unlocked.                                             
+
+
+### transfer
+
+Failed to initialize libusb.
+
+  Send transfer transaction
+
+  USAGE
+
+    symbol-cli transaction transfer [...options]
+
+  OPTIONS
+
+    --profile <profile>                             - (Optional) Select between your profiles, by providing a profile name.                                                  
+    -p, --password <password>                       - Profile password.                                                                                                      
+    -f, --max-fee <maxFee>                          - Maximum fee (absolute amount).                                                                                         
+    --sync                                          - (Optional) Wait until the server confirms or rejects the transaction.                                                  
+    --announce                                      - (Optional) Announce the transaction without double confirmation.                                                       
+    -M, --mode <mode>                               - Transaction announcement mode (normal, multisig)                                                                       
+    -S, --signer <signer>                           - (Multisig only) Transaction signer public key                                                                          
+    -F, --max-fee-hash-lock <maxFeeHashLock>        - (Multisig aggregate bonded only) Maximum fee (absolute amount) to announce the hash lock transaction.                  
+    -D, --lock-duration <lockDuration>              - (Multisig aggregate bonded only) Hash lock duration expressed in blocks. [480]                                         
+    -L, --lock-amount <lockAmount>                  - (Multisig aggregate bonded only) Relative amount of network mosaic to lock. [10]                                       
+    -r, --recipient-address <recipientAddress>      - Recipient address or @alias.                                                                                           
+    -m, --message <message>                         - Transaction message.                                                                                                   
+    -e, --encrypted                                 - (Optional) Send an encrypted message. If you set this value, you should set the value of 'recipientPublicKey' as well).
+    -c, --mosaics <mosaics>                         - Mosaic to transfer in the format (mosaicId(hex)|@aliasName)::absoluteAmount. Add multiple mosaics with commas.         
+    -u, --recipient-public-key <recipientPublicKey> - (Optional) Recipient public key in an encrypted message.                                                               
+
+
+### votingkeylink
+
+Failed to initialize libusb.
+
+  Link an account with a BLS public key. Required for node operators willing to vote finalized blocks.    
+
+  USAGE
+
+    symbol-cli transaction votingkeylink [...options]
+
+  OPTIONS
+
+    --profile <profile>                       - (Optional) Select between your profiles, by providing a profile name.                                
+    -p, --password <password>                 - Profile password.                                                                                    
+    -f, --max-fee <maxFee>                    - Maximum fee (absolute amount).                                                                       
+    --sync                                    - (Optional) Wait until the server confirms or rejects the transaction.                                
+    --announce                                - (Optional) Announce the transaction without double confirmation.                                     
+    -M, --mode <mode>                         - Transaction announcement mode (normal, multisig)                                                     
+    -S, --signer <signer>                     - (Multisig only) Transaction signer public key                                                        
+    -F, --max-fee-hash-lock <maxFeeHashLock>  - (Multisig aggregate bonded only) Maximum fee (absolute amount) to announce the hash lock transaction.
+    -D, --lock-duration <lockDuration>        - (Multisig aggregate bonded only) Hash lock duration expressed in blocks. [480]                       
+    -L, --lock-amount <lockAmount>            - (Multisig aggregate bonded only) Relative amount of network mosaic to lock. [10]                     
+    -u, --linked-public-key <linkedPublicKey> - BLS Linked Public Key.                                                                               
+    --start-point <startPoint>                - Start Point.                                                                                         
+    --end-point <endPoint>                    - End Point.                                                                                           
+    -a, --action <action>                     - Alias action (Link, Unlink).                                                                         
+
+
+### vrfkeylink
+
+Failed to initialize libusb.
+
+  Link an account with a VRF public key. Required for all harvesting eligible accounts.
+
+  USAGE
+
+    symbol-cli transaction vrfkeylink [...options]
+
+  OPTIONS
+
+    --profile <profile>                       - (Optional) Select between your profiles, by providing a profile name.                                
+    -p, --password <password>                 - Profile password.                                                                                    
+    -f, --max-fee <maxFee>                    - Maximum fee (absolute amount).                                                                       
+    --sync                                    - (Optional) Wait until the server confirms or rejects the transaction.                                
+    --announce                                - (Optional) Announce the transaction without double confirmation.                                     
+    -M, --mode <mode>                         - Transaction announcement mode (normal, multisig)                                                     
+    -S, --signer <signer>                     - (Multisig only) Transaction signer public key                                                        
+    -F, --max-fee-hash-lock <maxFeeHashLock>  - (Multisig aggregate bonded only) Maximum fee (absolute amount) to announce the hash lock transaction.
+    -D, --lock-duration <lockDuration>        - (Multisig aggregate bonded only) Hash lock duration expressed in blocks. [480]                       
+    -L, --lock-amount <lockAmount>            - (Multisig aggregate bonded only) Relative amount of network mosaic to lock. [10]                     
+    -u, --linked-public-key <linkedPublicKey> - Linked Public Key.                                                                                   
+    -a, --action <action>                     - Alias action (Link, Unlink).                                                                         
+
+

--- a/source/cli.rst
+++ b/source/cli.rst
@@ -58,9 +58,7 @@ If you do not have a private key to create a profile, you can generate a new acc
 Commands
 ********
 
-These are the available commands for Symbol CLI separated by version.
+Symbol CLI is deprecated. These are the available commands for the latest `Symbol CLI <https://github.com/symbol/symbol-docs/blob/main/source/_static/retired/symbol-cli/1.0.2.md>`__.
 
 Find out which CLI version do you have installed by running ``symbol-cli`` from the command line.
 
-.. ghreference:: symbol/symbol-cli
-    :folder:

--- a/source/compatibility.rst
+++ b/source/compatibility.rst
@@ -49,5 +49,4 @@ Tools
     `v0.9.4.1`_; v0.9.11; v0.19.4
 
 - `Desktop Wallet CHANGELOG <https://github.com/symbol/symbol-desktop-wallet/blob/main/CHANGELOG.md>`_
-- `symbol-cli CHANGELOG <https://github.com/symbol/symbol-cli/blob/main/CHANGELOG.md>`_
 - `symbol-bootstrap CHANGELOG <https://github.com/fboucquez/symbol-bootstrap/blob/main/CHANGELOG.md>`_

--- a/source/guides/network/creating-a-private-test-net.rst
+++ b/source/guides/network/creating-a-private-test-net.rst
@@ -185,4 +185,4 @@ We recommend you continue reading the rest of :ref:`the guides <blog-categories>
 
 .. |symbol-cli| raw:: html
 
-   <a href="https://github.com/symbol/symbol-cli" target="_blank">symbol-cli</a>
+   <a href="https://www.npmjs.com/package/symbol-cli" target="_blank">symbol-cli</a>

--- a/source/guides/network/running-a-secure-symbol-node.rst
+++ b/source/guides/network/running-a-secure-symbol-node.rst
@@ -206,8 +206,6 @@ The following commands all use ``--max-fee 1000000`` which means that **1 XYM** 
 
    There is currently a limitation in ``symbol-cli`` which sets this deadline to **2 hours** after transaction creation, for all non-multisig transactions.
 
-   This is a known limitation which is `being tracked <https://github.com/symbol/symbol-cli/issues/373>`__.
-
 Remote key link
 ---------------
 


### PR DESCRIPTION
Updating all links to the symbol-cli repo since the tool is getting deprecated.