### PR TITLE
Fix broken link - Technical Reference

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -295,7 +295,7 @@ rst_prolog = """
 
 .. |techref| raw:: html
 
-   <a href="https://docs.symbol.dev/symbol-technicalref/main.pdf" target="_blank">Technical Reference</a>
+   <a href="https://symbol.github.io/symbol-technicalref/main.pdf" target="_blank">Technical Reference</a>
 """
 
 # -- Options for Epub output ----------------------------------------------


### PR DESCRIPTION
The intended PDF does not exist at https://docs.symbol.dev/symbol-technicalref/main.pdf as presently linked. 
The correct source file appears to be https://symbol.github.io/symbol-technicalref/main.pdf as per https://github.com/symbol/symbol-technicalref

Alternate approach would be to add a copy of the technical reference at https://docs.symbol.dev/symbol-technicalref/main.pdf

Loosely relates to #839 