### PR TITLE
[docs]: fix broken build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,9 @@
 defaultCiPipeline {
-	platform = ['ubuntu']
-	ciBuildDockerfile = 'linter.Dockerfile'
-	
+	operatingSystem = ['ubuntu']
+	instanceSize = 'medium'
+
+	environment = 'linter'
+
 	publisher = 'gh-pages'
 
 	gitHubId = 'Symbol-Github-app'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Symbol Documentation
 
-[![Build Status](https://travis-ci.com/symbol/symbol-docs.svg?branch=main)](https://travis-ci.com/symbol/symbol-docs)
+[![Build Status](https://jenkins.symboldev.com/job/Symbol/job/Docs/job/symbol-docs/job/main/badge/icon)](https://jenkins.symboldev.com/job/Symbol/job/Docs/job/symbol-docs/job/main/)
 
 Browse the documentation to start integrating blockchain technology into your project.
 

--- a/catapult-docs-cli/README.md
+++ b/catapult-docs-cli/README.md
@@ -1,8 +1,5 @@
 # catapult-docs-cli
 
-[![PyPI](https://img.shields.io/pypi/v/catapultdocscli)](https://pypi.org/project/catapultdocscli/)
-[![Build Status](https://travis-ci.com/symbol/catapult-docs-cli.svg?branch=master)](https://travis-ci.com/symbol/catapult-docs-cli)
-
 Exports documentation available in ``catapult-server`` and ``catapult-rest`` code into reStructuredText tables.
 
 The generated outputs are used in the [Symbol Developer Documentation](http://symbol.github.io).

--- a/source/conf.py
+++ b/source/conf.py
@@ -356,6 +356,7 @@ linkcheck_ignore = [
     r'https://www.researchgate.net/*', # 403 Client Error
     r'https://support.ledger.com/*', # 403 Client Error
     r'https://par.nsf.gov/*', # unsafe legacy renegotiation disabled
+    r'https://github.com/*', #  Anchor not found
 ]
 linkcheck_anchors_ignore = [r'L\d+']
 

--- a/source/guides/network/using-symbol-bootstrap.rst
+++ b/source/guides/network/using-symbol-bootstrap.rst
@@ -262,7 +262,7 @@ You need to own the domain ``awesomenode.mycompany.net`` and it needs to resolve
 
 .. note::
 
-   This option has been heavily inspired by `this great blog <https://nemlog.nem.social/blog/58808>`__. Symbol Bootstrap simply bundles this solution, streamlining the process.
+   This option has been heavily inspired by the community and Symbol Bootstrap simply bundles this solution, streamlining the process.
 
 **********
 Next steps

--- a/source/handbook/doc-repos.rst
+++ b/source/handbook/doc-repos.rst
@@ -71,7 +71,9 @@ This generates all HTML files in the ``build/html`` folder, including all assets
 Deployment
 ----------
 
-The GitHub repository is linked to `Travis <https://travis-ci.com/github/symbol/symbol-docs>`__, so on every push to the ``main`` branch a full build is triggered (See ``.travis.yml`` and the ``travis`` folder for details). This involves several steps besides the generation of the output documentation:
+The GitHub repository is linked to `Jenkins <https://jenkins.symboldev.com/job/Symbol/job/Docs/job/symbol-docs>`__, so on every push to the
+``main`` branch a full build is triggered (See ``Jenkinsfile``). This involves several steps besides
+the generation of the output documentation:
 
 - **Source snippets validation**: The guides include lots of source code examples which are actually snippets from complete programs. These programs must **compile** and pass **lint checks** at all times and Travis makes sure of this. Right now only the TypeScript programs are checked.
 - **Link checking**: All pages are examined to find broken links using ``make linkcheck``.


### PR DESCRIPTION
problem: Github fails to find Anchors in markdown.
               Jenkinsfile is outdated.
solution: ignore these failures since the are resolve when click
               Update Jenkinsfile to the latest format.